### PR TITLE
Ajoute un sélecteur de classe

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,13 @@
     <div class="container">
         <h1>Outil de Tirage au Sort</h1>
         
+        <div class="class-selector-container">
+            <label for="class-selector">Choisir une classe :</label>
+            <select id="class-selector"></select>
+        </div>
         <div class="group-selector-container">
             <label for="group-selector">Choisir un groupe :</label>
-            <select id="group-selector">
-                </select>
+            <select id="group-selector"></select>
         </div>
 
         <div class="liste-eleves-container">

--- a/script.js
+++ b/script.js
@@ -1,26 +1,29 @@
 document.addEventListener('DOMContentLoaded', () => {
     // --- PERSONNALISATION ---
-    // Données des élèves, maintenant correctement assignées aux groupes.
-    const groupes = {
-        "Groupe 1": [
-            "AJENGUI Adam", "ALI Arna", "BORIN Edith", "CAMARA Ibrahima", 
-            "CHACHUAT-BRENAS Flora", "CIULIN Ruti Bianca", "JIMENEZ TABORLA Luis", 
-            "MALUNDA Débora", "Amir", "José", "Janaeel"
-        ],
-        "Groupe 2": [
-            "BEJI Kaïna", "DAOUDA Ortence", "MHAMDI Ayoub", "NDIAYE Baba", 
-            "QADER Nawel", "RIGOUSTE Noemy", "ROCHE Emma", "SAHIN Béna", 
-            "TEKIN Sabri", "WADE Diadie", "YAHOUI Ilyess", "ZINGILA Andréas", "PETERSON"
-        ],
-        "Groupe 3": [
-            "BELAAGRADI Sheryne", "FALL SEYE Dame", "GIMENEZ Lenny", "KHOYA Néma", 
-            "LABEUR Ilana", "LAFFONT Jordan", "MABILLE Teiki", "MAHBOUB Kenza", 
-            "MOUTONNET-OLIVEIRA Yoni", "OUSSENI Ethan", "SAHIN Mina", "TALON Heather", 
-            "TAZABAEV Tamirlan", "TEKIN Sami"
-        ]
+    // Données des élèves, organisées par classe puis par groupe.
+    const classes = {
+        "Classe A": {
+            "Groupe 1": [
+                "AJENGUI Adam", "ALI Arna", "BORIN Edith", "CAMARA Ibrahima",
+                "CHACHUAT-BRENAS Flora", "CIULIN Ruti Bianca", "JIMENEZ TABORLA Luis",
+                "MALUNDA Débora", "Amir", "José", "Janaeel"
+            ],
+            "Groupe 2": [
+                "BEJI Kaïna", "DAOUDA Ortence", "MHAMDI Ayoub", "NDIAYE Baba",
+                "QADER Nawel", "RIGOUSTE Noemy", "ROCHE Emma", "SAHIN Béna",
+                "TEKIN Sabri", "WADE Diadie", "YAHOUI Ilyess", "ZINGILA Andréas", "PETERSON"
+            ],
+            "Groupe 3": [
+                "BELAAGRADI Sheryne", "FALL SEYE Dame", "GIMENEZ Lenny", "KHOYA Néma",
+                "LABEUR Ilana", "LAFFONT Jordan", "MABILLE Teiki", "MAHBOUB Kenza",
+                "MOUTONNET-OLIVEIRA Yoni", "OUSSENI Ethan", "SAHIN Mina", "TALON Heather",
+                "TAZABAEV Tamirlan", "TEKIN Sami"
+            ]
+        }
     };
 
     // --- ÉLÉMENTS DE LA PAGE ---
+    const classSelector = document.getElementById('class-selector');
     const groupSelector = document.getElementById('group-selector');
     const listeElevesEl = document.getElementById('liste-eleves-interactive');
     const resultatContenuEl = document.getElementById('resultat-contenu');
@@ -53,34 +56,50 @@ document.addEventListener('DOMContentLoaded', () => {
      * Met à jour l'affichage en fonction du groupe sélectionné.
      */
     function mettreAJourAffichage() {
+        const selectedClass = classSelector.value;
         const selectedGroup = groupSelector.value;
         let elevesAAfficher = [];
 
         if (selectedGroup === "Tous") {
-            // Concatène tous les groupes en une seule liste
-            elevesAAfficher = Object.values(groupes).flat();
+            // Concatène tous les groupes de la classe en une seule liste
+            elevesAAfficher = Object.values(classes[selectedClass]).flat();
         } else {
-            elevesAAfficher = groupes[selectedGroup];
+            elevesAAfficher = classes[selectedClass][selectedGroup];
         }
-        
+
         creerListeInteractive(elevesAAfficher.sort()); // Trie par ordre alphabétique pour plus de clarté
         resultatContenuEl.innerHTML = '<p>Les résultats s\'afficheront ici...</p>';
     }
 
     /**
-     * Initialise le menu de sélection des groupes.
+     * Initialise les sélecteurs de classe et de groupe.
      */
-    function initialiserSelecteurGroupe() {
-        // Ajoute l'option pour voir tous les élèves
+    function initialiserSelecteurs() {
+        classSelector.innerHTML = '';
+        Object.keys(classes).forEach(nomClasse => {
+            const option = document.createElement('option');
+            option.value = nomClasse;
+            option.textContent = nomClasse;
+            classSelector.appendChild(option);
+        });
+        mettreAJourGroupes();
+    }
+
+    /**
+     * Met à jour la liste des groupes selon la classe sélectionnée.
+     */
+    function mettreAJourGroupes() {
+        const selectedClass = classSelector.value;
         groupSelector.innerHTML = '<option value="Tous">Tous les groupes</option>';
-        
-        // Ajoute une option pour chaque groupe
-        Object.keys(groupes).forEach(nomGroupe => {
+
+        Object.keys(classes[selectedClass]).forEach(nomGroupe => {
             const option = document.createElement('option');
             option.value = nomGroupe;
             option.textContent = nomGroupe;
             groupSelector.appendChild(option);
         });
+
+        mettreAJourAffichage();
     }
 
     function getElevesPresents() {
@@ -145,11 +164,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- ÉCOUTEURS D'ÉVÉNEMENTS ---
+    classSelector.addEventListener('change', mettreAJourGroupes);
     groupSelector.addEventListener('change', mettreAJourAffichage);
     btnTirageSimple.addEventListener('click', lancerTirageSimple);
     btnCreerGroupes.addEventListener('click', formerLesGroupes);
 
     // --- INITIALISATION ---
-    initialiserSelecteurGroupe();
-    mettreAJourAffichage(); // Affiche la liste initiale ("Tous les groupes")
+    initialiserSelecteurs();
 });

--- a/style.css
+++ b/style.css
@@ -28,6 +28,29 @@ h1, h2 {
     margin-top: 0;
 }
 
+/* Style pour le sélecteur de classe */
+.class-selector-container {
+    margin-bottom: 25px;
+    background-color: #f9f9f9;
+    padding: 15px;
+    border-radius: 8px;
+    border: 1px solid #ddd;
+}
+.class-selector-container label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+    color: #333;
+}
+#class-selector {
+    width: 100%;
+    padding: 10px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    font-family: 'Poppins', sans-serif;
+    font-size: 1em;
+}
+
 /* Style pour le sélecteur de groupe */
 .group-selector-container {
     margin-bottom: 25px;


### PR DESCRIPTION
## Summary
- Ajout d'un sélecteur de classe pour filtrer les élèves avant le sélecteur de groupe
- Déplacement du style du sélecteur de groupe vers un doublon pour le sélecteur de classe
- Réécriture du script pour initialiser et mettre à jour les listes selon la classe choisie

## Testing
- `npm test` *(échoué : Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b487f781a88326bdd3385fba81ad56