### PR TITLE
Align class selector styling with group selector

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,18 +30,20 @@ h1, h2 {
 
 /* Style pour le sélecteur de groupe */
 .group-selector-container {
-    margin-bottom: 25px;
+    margin: 0 0 25px 0;
     background-color: #f9f9f9;
     padding: 15px;
     border-radius: 8px;
     border: 1px solid #ddd;
 }
+
 .group-selector-container label {
     display: block;
     margin-bottom: 8px;
     font-weight: 600;
     color: #333;
 }
+
 #group-selector {
     width: 100%;
     padding: 10px;
@@ -50,20 +52,23 @@ h1, h2 {
     font-family: 'Poppins', sans-serif;
     font-size: 1em;
 }
+
 /* Style pour le sélecteur de classe */
 .class-selector-container {
-    margin-bottom: 25px;
+    margin: 0 0 25px 0;
     background-color: #f9f9f9;
     padding: 15px;
     border-radius: 8px;
     border: 1px solid #ddd;
 }
+
 .class-selector-container label {
     display: block;
     margin-bottom: 8px;
     font-weight: 600;
     color: #333;
 }
+
 #class-selector {
     width: 100%;
     padding: 10px;


### PR DESCRIPTION
## Summary
- Style `.class-selector-container` using the same block as the group selector
- Explicit margins to keep class and group selectors aligned

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b490231c0483268daf8d3542a25e51