### PR TITLE
feat: initialize selectors and update groups dynamically

### DIFF
--- a/script.js
+++ b/script.js
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
         resultatContenuEl.innerHTML = '<p>Les résultats s\'afficheront ici...</p>';
     }
 
-    function initialiserSelecteurClasses() {
+    function initialiserSelecteurs() {
         classSelector.innerHTML = '';
         Object.keys(classes).forEach(nomClasse => {
             const option = document.createElement('option');
@@ -80,9 +80,10 @@ document.addEventListener('DOMContentLoaded', () => {
             option.textContent = nomClasse;
             classSelector.appendChild(option);
         });
+        mettreAJourGroupes();
     }
 
-    function mettreAJourSelecteurGroupes() {
+    function mettreAJourGroupes() {
         const selectedClass = classSelector.value;
         groupSelector.innerHTML = '<option value="Tous">Tous les groupes</option>';
         Object.keys(classes[selectedClass]).forEach(nomGroupe => {
@@ -91,6 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
             option.textContent = nomGroupe;
             groupSelector.appendChild(option);
         });
+        mettreAJourAffichage();
     }
 
     function getElevesPresents() {
@@ -155,16 +157,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- ÉCOUTEURS D'ÉVÉNEMENTS ---
-    classSelector.addEventListener('change', () => {
-        mettreAJourSelecteurGroupes();
-        mettreAJourAffichage();
-    });
+    classSelector.addEventListener('change', mettreAJourGroupes);
     groupSelector.addEventListener('change', mettreAJourAffichage);
     btnTirageSimple.addEventListener('click', lancerTirageSimple);
     btnCreerGroupes.addEventListener('click', formerLesGroupes);
 
     // --- INITIALISATION ---
-    initialiserSelecteurClasses();
-    mettreAJourSelecteurGroupes();
-    mettreAJourAffichage();
+    initialiserSelecteurs();
 });


### PR DESCRIPTION
## Summary
- Initialize class and group dropdowns with a new `initialiserSelecteurs` function
- Dynamically refresh available groups on class change
- Adjust display logic to use both selected class and group

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b49023bdf883268fea04a52cc2d375